### PR TITLE
Fix the marching-cubes mesh extraction from the poisson reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v0.3.1
+
+- Fix the extraction of a mesh from the poisson reconstruction.
+- Add `PoissonReconstruction::reconstruct_trimesh` and `::reconstruct_mesh_buffers` for extracting
+  a triangle mesh with properly wired-up topology.
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poisson_reconstruction"
 repository = "https://github.com/ForesightMiningSoftwareCorporation/PoissonReconstruction"
-version = "0.3.0"
+version = "0.3.1"
 license = "MIT OR Apache-2.0"
 description = "Screened Poisson Reconstruction algorithm in Rust"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ itertools = "0.10"
 fnv = "1"
 
 [dev-dependencies]
-bevy = "0.9"
+bevy = "0.15"
+bevy_panorbit_camera = "0.22"
 ply-rs = "0.1"


### PR DESCRIPTION
- Fix the extraction of a mesh from the poisson reconstruction. Sometimes it would create meshes with holes.
- Add `PoissonReconstruction::reconstruct_trimesh` and `::reconstruct_mesh_buffers` for extracting
  a triangle mesh with properly wired-up topology.